### PR TITLE
Fix when the preferred balance is exceeded on deposit

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -71,5 +71,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@marinade.finance/marinade-ts-sdk": "^4.0.4"
   }
 }

--- a/packages/app/src/components/TweetButton.tsx
+++ b/packages/app/src/components/TweetButton.tsx
@@ -8,7 +8,7 @@ interface TweetButtonProps {
   t: Toast;
 }
 
-const TweetButton: React.FC<TweetButtonProps> = ({ amount, t }) => {
+const TweetButton: React.FC<TweetButtonProps> = ({ t }) => {
   useScript("https://platform.twitter.com/widgets.js");
 
   return (
@@ -54,7 +54,7 @@ const TweetButton: React.FC<TweetButtonProps> = ({ amount, t }) => {
           href="https://twitter.com/share?ref_src=twsrc%5Etfw"
           className="twitter-share-button"
           data-size="large"
-          data-text="I just staked with Sunrise, offsetting carbon and making Solana stronger"
+          data-text="I just staked with Sunrise, offsetting carbon and making Solana stronger."
           data-url="https://app.sunrisestake.com/"
           data-via="sunrisestake"
           // data-hashtags=""

--- a/packages/tests/sunrise-stake.ts
+++ b/packages/tests/sunrise-stake.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_LP_PROPORTION,
   NETWORK_FEE,
 } from "@sunrisestake/app/src/lib/constants";
+import { MarinadeConfig, Marinade } from "@marinade.finance/marinade-ts-sdk";
 
 chai.use(chaiAsPromised);
 
@@ -346,5 +347,53 @@ describe("sunrise-stake", () => {
     // marinade charges a 0.3% fee for liquid unstaking
     const expectedTreasuryBalance = new BN(burnLamports).muln(997).divn(1000);
     await expectTreasurySolBalance(client, expectedTreasuryBalance, 10);
+  });
+
+  /**
+   * This test generates a situation where the liquidity pool balance is overfull, by adding fees to the pool.
+   */
+  it("can deposit sol after fees are sent to the liquidity pool, increasing the value of the liquidity pool tokens", async () => {
+    if (!client.marinade) {
+      throw new Error("Marinade state not initialized");
+    }
+
+    let details = await client.details();
+
+    // deposit directly into marinade, and withdrawing again, in order to add fees to the pool
+    // raising its value above the preferred amount.
+    const marinadeConfig = new MarinadeConfig({
+      connection: client.provider.connection,
+      publicKey: client.provider.publicKey,
+    });
+    const marinade = new Marinade(marinadeConfig);
+
+    log("LP Sol Value: ", details.lpDetails.lpSolValue.toNumber());
+    // Simulate fees being sent to the liquidity pool
+    log("Depositing directly into marinade");
+    let { transaction } = await marinade.deposit(
+      new BN(100000 * LAMPORTS_PER_SOL)
+    );
+    await client.provider.sendAndConfirm(transaction);
+    log("Liquid unstaking from marinade, sending fees into the liquidity pool");
+    ({ transaction } = await marinade.liquidUnstake(
+      new BN(90000 * LAMPORTS_PER_SOL)
+    ));
+    await client.provider.sendAndConfirm(transaction);
+    details = await client.details();
+    log("LP Sol Value: ", details.lpDetails.lpSolValue.toNumber());
+    log("preferred lp value", Number(details.balances.gsolSupply.amount) * 0.1);
+
+    const liqPoolBalance =
+      await client.provider.connection.getTokenAccountBalance(
+        client.liqPoolTokenAccount!
+      );
+
+    await client.deposit(new BN(0.01 * LAMPORTS_PER_SOL));
+
+    // the deposit should not increase the balance of the liquidity pool tokens
+    await expectLiqPoolTokenBalance(
+      client,
+      new BN(liqPoolBalance.value.amount)
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,17 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@marinade.finance/marinade-ts-sdk@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@marinade.finance/marinade-ts-sdk/-/marinade-ts-sdk-4.0.4.tgz#f17fd8c89fb2eba9b801d0ae925ef978e4280ac0"
+  integrity sha512-JTqK1p+MLXWR5+jj/YWviylrBQDGUlSzcOATW+J/GLHeAtMGDqdw52scvcooq0dOl3J222PAQico9D3CUD2Wag==
+  dependencies:
+    "@project-serum/anchor" "^0.18.2"
+    "@solana/spl-token" "^0.3.6"
+    bignumber.js "^9.1.0"
+    borsh "^0.6.0"
+    bs58 "^5.0.0"
+
 "@metaplex-foundation/beet-solana@^0.3.0", "@metaplex-foundation/beet-solana@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet-solana/-/beet-solana-0.3.1.tgz#4b37cda5c7f32ffd2bdd8b3164edc05c6463ab35"


### PR DESCRIPTION
When the preferred liquidity pool balance is lower than the actual liquidity pool balance, deposits failed due to a checked_sub() call causing a panic in the program. Replaced safely with saturating_sub.