### PR TITLE
Some general balance fixes and prep for enabling solblaze.

### DIFF
--- a/packages/app/src/common/components/AmountInput.tsx
+++ b/packages/app/src/common/components/AmountInput.tsx
@@ -1,16 +1,19 @@
 import clx from "classnames";
-import { toSol } from "@sunrisestake/client";
+import { MAX_NUM_PRECISION, toSol } from "@sunrisestake/client";
 import type BN from "bn.js";
 import React from "react";
 import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
 
 import {
   getDigits,
+  lamportsToDisplay,
   solToLamports,
   toFixedWithPrecision,
   type UIMode,
   ZERO,
 } from "../utils";
+import { tooltips } from "../content/tooltips";
+import { TooltipPopover } from "./TooltipPopover";
 
 interface AmountInputProps {
   className?: string;
@@ -68,6 +71,7 @@ const AmountInput: React.FC<AmountInputProps> = ({
   };
 
   const updateAmount = (amountStr: string): void => {
+    console.log("amountStr ", amountStr);
     const parsedValue = solToLamports(amountStr);
     const min = ZERO;
     const max = getMaxBalance();
@@ -101,22 +105,23 @@ const AmountInput: React.FC<AmountInputProps> = ({
       >
         <div className="grow my-auto">
           {showBalance && (
-            <div className="text-right">
+            <div className="flex items-center justify-end">
               Balance:{" "}
               <button
                 className="px-2 py-1 rounded-md hover:bg-green text-green hover:text-white"
                 onClick={() => {
                   if (balance) {
                     updateAmount(
-                      toFixedWithPrecision(
-                        mode === "STAKE" ? toSol(balance) - 0.1 : toSol(balance)
-                      ).toString()
+                      lamportsToDisplay(getMaxBalance(), MAX_NUM_PRECISION)
                     );
                   }
                 }}
               >
-                {balance ? toFixedWithPrecision(toSol(balance)) : "-"} {token}
+                {balance ? lamportsToDisplay(balance) : "-"} {token}
               </button>
+              {(mode === "UNSTAKE" || mode === "LOCK") && (
+                <TooltipPopover>{tooltips.unstakeBalance}</TooltipPopover>
+              )}
             </div>
           )}
           <div className="flex">

--- a/packages/app/src/common/components/DetailsBox.tsx
+++ b/packages/app/src/common/components/DetailsBox.tsx
@@ -1,11 +1,11 @@
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
-import { type Details, toSol } from "@sunrisestake/client";
+import { type Details } from "@sunrisestake/client";
 import BN from "bn.js";
 import clx from "classnames";
 import { type FC, type ReactNode, useRef, useState } from "react";
 
 import { tooltips } from "../content/tooltips";
-import { toFixedWithPrecision } from "../utils";
+import { lamportsToDisplay } from "../utils";
 import { TooltipPopover } from "./TooltipPopover";
 
 interface DetailEntryProps {
@@ -70,9 +70,6 @@ const DetailsBox: FC<Props> = ({ className, details }) => {
   const yieldShare =
     extractableYield.muln(1_000).div(totalValue).toNumber() / 10;
   const gSolSupply = new BN(details.balances.gsolSupply.amount);
-
-  const lamportsToDisplay = (lamports: BN): string =>
-    toFixedWithPrecision(toSol(lamports), 2);
 
   return (
     <>

--- a/packages/app/src/common/content/tooltips.tsx
+++ b/packages/app/src/common/content/tooltips.tsx
@@ -1,5 +1,6 @@
 const tooltips = {
   yourStake: <>Your staked SOL and locked gSOL</>,
+  unstakeBalance: <>Your unlocked gSOL</>,
   totalStake: <>The sum of everyones staked SOL</>,
   offsetCO2: (
     <>

--- a/packages/app/src/common/utils.ts
+++ b/packages/app/src/common/utils.ts
@@ -1,6 +1,6 @@
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { type SignerWalletAdapterProps } from "@solana/wallet-adapter-base";
-import { MAX_NUM_PRECISION } from "@sunrisestake/client";
+import { MAX_NUM_PRECISION, toSol } from "@sunrisestake/client";
 import BN from "bn.js";
 import {
   NotificationType,
@@ -50,18 +50,15 @@ const solToLamports = (sol: number | string): BN => {
   return new BN(formattedNum);
 };
 
-// Get the number of decimal places to show in a formatted number
-// Min = 0, Max = MAX_NUM_PRECISION
-const formatPrecision = (n: number, precision = MAX_NUM_PRECISION): number =>
-  Math.min(
-    Math.abs(Math.min(0, Math.ceil(Math.log(n) / Math.log(10)))) + 1,
-    precision
-  );
+export const lamportsToDisplay = (
+  lamports: BN,
+  precision: number = 2
+): string => toFixedWithPrecision(toSol(lamports), precision);
 
 const toFixedWithPrecision = (
   n: number,
   precision = MAX_NUM_PRECISION
-): string => n.toFixed(formatPrecision(n, precision));
+): string => String(Number(n.toFixed(precision)));
 
 const getDigits = (strNo: string): number | undefined => {
   const match = strNo.match(/^\d*\.(\d+)$/);

--- a/packages/app/src/grow/partners.ts
+++ b/packages/app/src/grow/partners.ts
@@ -5,15 +5,15 @@ export const partnerApps = [
     imageUrl: "partners/AEL_Logo.jpg",
   },
   {
-    name: "Partner",
+    name: "Partner 1",
     imageUrl: "partners/partner0.png",
   },
   {
-    name: "Partner",
+    name: "Partner 2",
     imageUrl: "partners/partner1.png",
   },
   {
-    name: "Partner",
+    name: "Partner 3",
     imageUrl: "partners/partner2.png",
   },
 ];

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -6,7 +6,7 @@ import BN from "bn.js";
 export const MAX_NUM_PRECISION = 5;
 
 // on devnet, the solblaze pool is sometimes unavailable for deposits - use this to disable it
-export const SOLBLAZE_ENABLED = false;
+export const SOLBLAZE_ENABLED = true;
 
 export const STAKE_POOL_PROGRAM_ID = new PublicKey(
   "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy"
@@ -43,7 +43,7 @@ export const Environment: Record<
     yieldControllerState: new PublicKey(
       "DzyP73X4TWnh5jarfjapaNBxtjeEVsfknWVfToRYARDL" // Buy & Burn Yield Controller
     ),
-    percentageStakeToMarinade: 200, // TODO TEMP fix
+    percentageStakeToMarinade: 75,
     blaze: {
       pool: new PublicKey("stk9ApL5HeVAwPLr3TLhDXdZS8ptVu7zp6ov8HFDuMi"),
       bsolMint: new PublicKey("bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1"),

--- a/packages/client/src/util.ts
+++ b/packages/client/src/util.ts
@@ -351,5 +351,22 @@ export const marinadeTargetReached = (
     new BN(100)
   );
 
+  const lpShare =
+    details.lpDetails.lpSolValue.muln(1_000).div(totalValue).toNumber() / 10;
+
+  // We set this to <10% because, when depositing to Marinade, the lp share
+  // never actually reaches 10%. Amounts are split across both the LP and SP
+  // such that the LP balance asymptotically approaches 10% without ever
+  // reaching it.
+  // Therefore, 9 is a healthy value. If the LP share is lower than that,
+  // we should send to Marinade.
+  // TODO move to a constant
+  if (lpShare < 9) {
+    console.log(
+      `LP share is ${lpShare}%, which is below the minimum of 10%. Should send to Marinade.`
+    );
+    return false;
+  }
+
   return totalMarinade.gt(limit);
 };


### PR DESCRIPTION
- The format precision function was always showing 1dp when it should have shown more
- Take the lp balance into account when deciding whether to stake with solblaze, if the lp is below 9%, route to marinade