### PR TITLE
Feature/deposit and send

### DIFF
--- a/packages/app/src/common/components/AmountInput.tsx
+++ b/packages/app/src/common/components/AmountInput.tsx
@@ -71,19 +71,11 @@ const AmountInput: React.FC<AmountInputProps> = ({
   };
 
   const updateAmount = (amountStr: string): void => {
-    console.log("amountStr ", amountStr);
     const parsedValue = solToLamports(amountStr);
     const min = ZERO;
     const max = getMaxBalance();
 
-    console.log("parsedValue ", parsedValue.toString());
-
     setAmount(amountStr);
-    console.log(`Min: ${min.toNumber()}`);
-    console.log(`Max: ${max.toNumber()}`);
-    console.log(
-      `Valid: ${parsedValue.gt(min) && parsedValue.lte(max) ? "true" : "false"}`
-    );
     setValid(parsedValue.gt(min) && parsedValue.lte(max));
   };
 
@@ -106,7 +98,7 @@ const AmountInput: React.FC<AmountInputProps> = ({
         <div className="grow my-auto">
           {showBalance && (
             <div className="flex items-center justify-end">
-              Balance:{" "}
+              Available Balance:{" "}
               <button
                 className="px-2 py-1 rounded-md hover:bg-green text-green hover:text-white"
                 onClick={() => {

--- a/packages/app/src/common/components/CurrencySelect.tsx
+++ b/packages/app/src/common/components/CurrencySelect.tsx
@@ -1,0 +1,66 @@
+import { type FC, Fragment } from "react";
+import { Listbox, Transition } from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+
+type SupportedCurrency = "SOL" | "gSOL";
+const currencies: SupportedCurrency[] = ["gSOL", "SOL"];
+
+interface Props {
+  selected: SupportedCurrency;
+  select: (currency: SupportedCurrency) => void;
+}
+
+export const CurrencySelect: FC<Props> = ({ selected, select }) => {
+  return (
+    <Listbox value={selected} onChange={select}>
+      <div className="relative mt-1">
+        <Listbox.Button className="relative cursor-default rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm">
+          <span className="block truncate">{selected}</span>
+          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+            <ChevronUpDownIcon
+              className="h-5 w-5 text-gray-400"
+              aria-hidden="true"
+            />
+          </span>
+        </Listbox.Button>
+        <Transition
+          as={Fragment}
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Listbox.Options className="absolute mt-1 max-h-60 w-32 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+            {currencies.map((currency, currencyIdx) => (
+              <Listbox.Option
+                key={currencyIdx}
+                className={({ active }) =>
+                  `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                    active ? "bg-amber-100 text-amber-900" : "text-gray-900"
+                  }`
+                }
+                value={currency}
+              >
+                {({ selected }) => (
+                  <>
+                    <span
+                      className={`block truncate ${
+                        selected ? "font-medium" : "font-normal"
+                      }`}
+                    >
+                      {currency}
+                    </span>
+                    {selected ? (
+                      <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
+                        <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                    ) : null}
+                  </>
+                )}
+              </Listbox.Option>
+            ))}
+          </Listbox.Options>
+        </Transition>
+      </div>
+    </Listbox>
+  );
+};

--- a/packages/app/src/common/components/modals/SendGSolModal.tsx
+++ b/packages/app/src/common/components/modals/SendGSolModal.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useCallback, useState } from "react";
+import React, { type FC, useCallback, useMemo, useState } from "react";
 
 import { BaseModal, type ModalProps } from "./";
 import { PublicKey, Transaction } from "@solana/web3.js";
@@ -18,6 +18,8 @@ import {
   getAssociatedTokenAddress,
 } from "@solana/spl-token";
 import { NotificationType, notifyTransaction } from "../notifications";
+import { CurrencySelect } from "../CurrencySelect";
+import { useSolBalance } from "../../hooks/useSolBalance";
 
 interface SendGSolModalProps {
   recipient?: {
@@ -34,14 +36,14 @@ const SendGSolModal: FC<ModalProps & SendGSolModalProps> = ({
   ...props
 }) => {
   const [amount, setAmount] = useState("");
-
   const [isBusy, setIsBusy] = useState(false);
   const [isValid, setIsValid] = useState(false);
-
-  const { details } = useSunriseStake();
+  const { details, client } = useSunriseStake();
   const { publicKey: senderPubkey, sendTransaction } = useWallet();
   const { connection } = useConnection();
   const [recipient, setRecipient] = useState(recipientFromProps);
+  const [currency, setCurrency] = useState<"gSOL" | "SOL">("SOL");
+  const solBalance = useSolBalance();
 
   const updateRecipientFromForm = useCallback(
     (addressString: string) => {
@@ -101,7 +103,44 @@ const SendGSolModal: FC<ModalProps & SendGSolModalProps> = ({
       })
       .catch(handleError);
     console.log("Transfer signature:", signature);
-  }, [recipient, amount, senderPubkey, details, connection, sendTransaction]);
+  }, [recipient, amount, senderPubkey, details, sendTransaction]);
+
+  const depositGSol = useCallback(async (): Promise<void> => {
+    if (!client || !recipient) {
+      return;
+    }
+
+    const signature = await client
+      .deposit(solToLamports(amount), recipient.address)
+      .then((txSig) => {
+        notifyTransaction({
+          type: NotificationType.success,
+          message: "Transfer successful",
+          txid: txSig,
+        });
+        return txSig;
+      })
+      .catch(handleError);
+    console.log("Transfer signature:", signature);
+  }, [recipient, amount, client, sendTransaction]);
+
+  const send = useCallback(async (): Promise<void> => {
+    if (currency === "gSOL") {
+      await transferGSol();
+    } else {
+      await depositGSol();
+    }
+  }, [currency, transferGSol, depositGSol]);
+
+  const balance = useMemo(() => {
+    if (!details) return ZERO;
+
+    if (currency === "gSOL") {
+      return new BN(details.balances.gsolBalance.amount);
+    } else {
+      return solBalance;
+    }
+  }, [details, currency]);
 
   return (
     <BaseModal {...props} showActions={false}>
@@ -112,11 +151,13 @@ const SendGSolModal: FC<ModalProps & SendGSolModalProps> = ({
         )}
       >
         <div className="flex flex-col">
-          <div className="font-semibold text-xl mb-2">
-            To{" "}
+          <div className="flex flex-row">
+            <div className="font-semibold text-xl m-2">Send</div>
+            <CurrencySelect selected={currency} select={setCurrency} />
+            <div className="font-semibold text-xl m-2">To</div>
             {recipientFromProps && (
               <a
-                className="font-normal text-lg text-green"
+                className="font-normal text-lg text-green py-1 mt-1"
                 href={recipient?.website}
                 target="_blank"
                 rel="noreferrer"
@@ -125,36 +166,34 @@ const SendGSolModal: FC<ModalProps & SendGSolModalProps> = ({
                   (recipient?.address && toShortBase58(recipient.address))}
               </a>
             )}
+            {!recipientFromProps && (
+              <input
+                className="mb-4 mt-1 rounded-md text-sm xl:text-lg py-1 px-4 placeholder:text-sm"
+                onChange={(e) => {
+                  updateRecipientFromForm(e.target.value);
+                }}
+                defaultValue={recipient?.address?.toBase58() ?? ""}
+                placeholder="Address"
+              />
+            )}
           </div>
-          {!recipientFromProps && (
-            <input
-              className="mb-4 rounded-md text-sm xl:text-lg py-3 px-4 placeholder:text-sm"
-              onChange={(e) => {
-                updateRecipientFromForm(e.target.value);
-              }}
-              defaultValue={recipient?.address?.toBase58() ?? ""}
-              placeholder="Address"
-            />
-          )}
-          <div className="font-semibold text-xl mb-2">Send gSOL</div>
-          <div className="">
+          <div className="flex flex-row gap-2 mt-4">
             <AmountInput
-              className="basis-3/4"
-              token="gSOL"
-              balance={new BN(details?.balances.gsolBalance.amount ?? ZERO)}
+              className="w-full"
+              token={currency}
+              balance={balance}
               amount={amount}
               setAmount={setAmount}
               setValid={setIsValid}
               mode="TRANSFER"
               variant="small"
             />
-
             <div className="mt-4 float-right cleafix">
               <Button
                 className="basis-1/4"
                 onClick={() => {
                   setIsBusy(true);
-                  transferGSol().finally(() => {
+                  send().finally(() => {
                     setIsBusy(false);
                     props.ok();
                   });

--- a/packages/app/src/common/hooks/useSolBalance.ts
+++ b/packages/app/src/common/hooks/useSolBalance.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { toBN, ZERO } from "../utils";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import type BN from "bn.js";
+
+export const useSolBalance = (): BN => {
+  const [solBalance, setSolBalance] = useState(ZERO);
+  const { connection } = useConnection();
+  const wallet = useWallet();
+  useEffect(() => {
+    if (wallet?.publicKey) {
+      connection
+        .getBalance(wallet.publicKey)
+        .then(toBN)
+        .then(setSolBalance)
+        .catch(console.error);
+
+      const subscription = connection.onAccountChange(
+        wallet.publicKey,
+        (info) => {
+          setSolBalance(toBN(info.lamports));
+        }
+      );
+
+      return () => {
+        connection
+          .removeAccountChangeListener(subscription)
+          .catch(console.error);
+      };
+    }
+  }, [wallet.publicKey]);
+
+  return solBalance;
+};

--- a/packages/app/src/common/sunriseClientWrapper.ts
+++ b/packages/app/src/common/sunriseClientWrapper.ts
@@ -90,10 +90,10 @@ export class SunriseClientWrapper {
     return result;
   };
 
-  async deposit(amount: BN): Promise<string> {
+  async deposit(amount: BN, recipient?: PublicKey): Promise<string> {
     if (this.readonlyWallet) throw new Error("Readonly wallet");
     return this.client
-      .makeBalancedDeposit(amount)
+      .makeBalancedDeposit(amount, recipient)
       .then(async (tx) => this.client.sendAndConfirmTransaction(tx));
     // .then(this.triggerUpdateAndReturn.bind(this));
   }

--- a/packages/app/src/grow/GrowApp.tsx
+++ b/packages/app/src/grow/GrowApp.tsx
@@ -44,7 +44,7 @@ const isRealPartner = (
 
 const Placeholder: FC<PropsWithChildren> = ({ children }) => (
   <div className="text-green-light border border-green-light p-8 rounded-md w-40 h-40 hover:scale-110 hover:brightness-125 hover:transition-all text-green text-xl font-medium text-center">
-    {children}
+    <div className="pt-4">{children}</div>
   </div>
 );
 
@@ -108,9 +108,7 @@ const _GrowApp: ForwardRefRenderFunction<
       <div className="w-full sm:w-[90%] md:w-[70%] lg:w-[50%] max-w-xl">
         <div className="flex overflow-x-scroll gap-4 p-4">
           <CollectInfoButton>
-            <Placeholder>
-              <div className="pt-4">Your App Here</div>
-            </Placeholder>
+            <Placeholder>Your App Here</Placeholder>
           </CollectInfoButton>
           {partnerApps.map((app) =>
             isRealPartner(app) ? (
@@ -146,7 +144,7 @@ const _GrowApp: ForwardRefRenderFunction<
       </div>
       <div>
         <h2 className="container font-bold text-xl mt-8 mb-4 text-green text-center">
-          Send gSOL to add someone to your forest.
+          Send a gift to add someone to your forest.
         </h2>
         <div className="flex justify-center items-center mb-8">
           <Button

--- a/packages/app/src/staking/pages/StakeDashboard.tsx
+++ b/packages/app/src/staking/pages/StakeDashboard.tsx
@@ -1,4 +1,4 @@
-import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import { useWallet } from "@solana/wallet-adapter-react";
 import { type TicketAccount, type Details, toSol } from "@sunrisestake/client";
 import BN from "bn.js";
 import clx from "classnames";
@@ -9,7 +9,6 @@ import { GiCircleForest } from "react-icons/gi";
 
 import {
   solToLamports,
-  toBN,
   toFixedWithPrecision,
   ZERO,
   type UIMode,
@@ -33,10 +32,10 @@ import { type SunriseClientWrapper } from "../../common/sunriseClientWrapper";
 import { StakeForm, UnstakeForm, WithdrawTicket } from "../components";
 import { Link, useNavigate } from "react-router-dom";
 import { IoChevronUpOutline, IoChevronDownOutline } from "react-icons/io5";
+import { useSolBalance } from "../../common/hooks/useSolBalance";
 
 const StakeDashboard: FC = () => {
   const wallet = useWallet();
-  const { connection } = useConnection();
   const {
     client,
     details,
@@ -44,7 +43,7 @@ const StakeDashboard: FC = () => {
     client: SunriseClientWrapper | undefined;
     details: Details | undefined;
   } = useSunriseStake();
-  const [solBalance, setSolBalance] = useState<BN>();
+  const solBalance = useSolBalance();
   const [delayedWithdraw, setDelayedWithdraw] = useState(false);
   const [delayedUnstakeTickets, setDelayedUnstakeTickets] = useState<
     TicketAccount[]
@@ -57,7 +56,6 @@ const StakeDashboard: FC = () => {
   const updateBalances = async (): Promise<void> => {
     if (!wallet.publicKey || !client) return;
     try {
-      setSolBalance(await connection.getBalance(wallet.publicKey).then(toBN));
       setDelayedUnstakeTickets(await client.getDelayedUnstakeTickets());
     } catch (error) {
       console.error(error);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -379,7 +379,10 @@ export class SunriseStakeClient {
     const transaction = new Transaction();
 
     if (!gsolTokenAccount) {
-      const createUserTokenAccount = this.createGSolTokenAccountIx();
+      const createUserTokenAccount = this.createGSolTokenAccountIx(
+        recipientGsolTokenAccountAddress,
+        recipient
+      );
       transaction.add(createUserTokenAccount);
     }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -278,14 +278,16 @@ export class SunriseStakeClient {
     return txSigs;
   }
 
-  createGSolTokenAccountIx(): TransactionInstruction {
-    if (!this.stakerGSolTokenAccount || !this.config)
-      throw new Error("init not called");
+  createGSolTokenAccountIx(
+    account = this.stakerGSolTokenAccount,
+    authority = this.staker
+  ): TransactionInstruction {
+    if (!account || !this.config) throw new Error("init not called");
 
     return createAssociatedTokenAccountIdempotentInstruction(
       this.provider.publicKey,
-      this.stakerGSolTokenAccount,
-      this.staker,
+      account,
+      authority,
       this.config.gsolMint
     );
   }
@@ -303,7 +305,10 @@ export class SunriseStakeClient {
     return this.deposit(lamports);
   }
 
-  public async deposit(lamports: BN): Promise<Transaction> {
+  public async deposit(
+    lamports: BN,
+    recipient?: PublicKey
+  ): Promise<Transaction> {
     if (
       !this.marinadeState ||
       !this.marinade ||
@@ -312,14 +317,25 @@ export class SunriseStakeClient {
     )
       throw new Error("init not called");
 
+    const recipientAuthority = recipient ?? this.staker;
+    const recipientGsolTokenAccountAddress = recipient
+      ? await utils.token.associatedAddress({
+          mint: this.config.gsolMint,
+          owner: recipientAuthority,
+        })
+      : this.stakerGSolTokenAccount;
+
     const gsolTokenAccount = await this.provider.connection.getAccountInfo(
-      this.stakerGSolTokenAccount
+      recipientGsolTokenAccountAddress
     );
 
     const transaction = new Transaction();
 
     if (!gsolTokenAccount) {
-      const createUserTokenAccount = this.createGSolTokenAccountIx();
+      const createUserTokenAccount = this.createGSolTokenAccountIx(
+        recipientGsolTokenAccountAddress,
+        recipient
+      );
       transaction.add(createUserTokenAccount);
     }
 
@@ -330,7 +346,7 @@ export class SunriseStakeClient {
       this.marinadeState,
       this.config.stateAddress,
       this.provider.publicKey,
-      this.stakerGSolTokenAccount,
+      recipientGsolTokenAccountAddress,
       lamports
     );
 

--- a/packages/client/src/marinade.ts
+++ b/packages/client/src/marinade.ts
@@ -40,7 +40,7 @@ export const deposit = async (
   marinadeState: MarinadeState,
   stateAddress: PublicKey,
   staker: PublicKey,
-  stakerGsolTokenAccount: PublicKey,
+  recipientGsolTokenAccount: PublicKey,
   lamports: BN
 ): Promise<Transaction> => {
   const sunriseStakeState = await program.account.state.fetch(stateAddress);
@@ -79,7 +79,7 @@ export const deposit = async (
     transferFrom: staker,
     mintMsolTo: msolAssociatedTokenAccountAddress,
     mintLiqPoolTo: liqPoolAssociatedTokenAccountAddress,
-    mintGsolTo: stakerGsolTokenAccount,
+    mintGsolTo: recipientGsolTokenAccount,
     msolMintAuthority: await marinadeState.mSolMintAuthority(),
     msolTokenAccountAuthority,
     systemProgram: SystemProgram.programId,

--- a/packages/tests/sunrise-stake.ts
+++ b/packages/tests/sunrise-stake.ts
@@ -267,11 +267,29 @@ describe("sunrise-stake", () => {
     await expectLiqPoolTokenBalance(client, expectedLiqPool, 50);
   });
 
-  it("can deposit sol for someone else", async () => {
+  it("can deposit sol to marinade for someone else", async () => {
     const recipient = Keypair.generate();
     const lamportsToSend = new BN(100_000);
     await client.sendAndConfirmTransaction(
       await client.deposit(lamportsToSend, recipient.publicKey)
+    );
+
+    const recipientTokenAccountAddress = getAssociatedTokenAddressSync(
+      client.config!.gsolMint,
+      recipient.publicKey
+    );
+    const gsolBalance = await client.provider.connection.getTokenAccountBalance(
+      recipientTokenAccountAddress
+    );
+    log("Recipient's gSOL balance", gsolBalance.value.uiAmount);
+    expect(gsolBalance.value.amount).to.equal(lamportsToSend.toString());
+  });
+
+  it("can deposit sol to spl for someone else", async () => {
+    const recipient = Keypair.generate();
+    const lamportsToSend = new BN(100_000);
+    await client.sendAndConfirmTransaction(
+      await client.depositToBlaze(lamportsToSend, recipient.publicKey)
     );
 
     const recipientTokenAccountAddress = getAssociatedTokenAddressSync(

--- a/programs/sunrise-stake/src/instructions/deposit.rs
+++ b/programs/sunrise-stake/src/instructions/deposit.rs
@@ -75,7 +75,6 @@ pub struct Deposit<'info> {
     #[account(
     mut,
     token::mint = gsol_mint,
-    token::authority = transfer_from.key(),
     )]
     pub mint_gsol_to: Account<'info, TokenAccount>,
 

--- a/programs/sunrise-stake/src/sunrise_spl/deposit_sol.rs
+++ b/programs/sunrise-stake/src/sunrise_spl/deposit_sol.rs
@@ -42,8 +42,7 @@ pub struct SplDepositSol<'info> {
     pub depositor: Signer<'info>,
     #[account(
         mut,
-        token::mint = gsol_mint,
-        token::authority = depositor,
+        token::mint = gsol_mint
     )]
     pub depositor_gsol_token_account: Account<'info, TokenAccount>,
 


### PR DESCRIPTION
Deposit to recipient

- Change sunrise program to support sending to a token account not owned by the sender
- Adapt client to support the above
- Adapt SendGSolModal to allow the user to choose between SOL and gSOL when sending funds
- Refactor: Extracted getSolBalance into a hook

NOTE: The program is upgrade on devnet already. Before this is released to mainnet, we need to upgrade the program there too.