### PR TITLE
Include mints to recipients as transfers in the forest

### DIFF
--- a/packages/app/src/api/db.ts
+++ b/packages/app/src/api/db.ts
@@ -27,6 +27,7 @@ const buildTransferRecord = (transfer: TransferResponse): Transfer => ({
 const buildMintRecord = (mint: MintResponse): Mint => ({
   timestamp: new Date(mint.timestamp),
   recipient: new PublicKey(mint.recipient),
+  sender: mint.sender !== undefined ? new PublicKey(mint.sender) : undefined,
   amount: mint.amount,
 });
 const getDBData = async <T>(
@@ -60,7 +61,7 @@ const getDBData = async <T>(
   }).then(async (resp) => resp.json());
 };
 export const getAccountMints = async (address: PublicKey): Promise<Mint[]> =>
-  getDBData<MintResponse>("mints", ["recipient"], address)
+  getDBData<MintResponse>("mints", ["sender", "recipient"], address)
     .then((resp) => resp.documents)
     .then((mints) => mints.map(buildMintRecord));
 export const getAccountTransfers = async (

--- a/packages/app/src/api/types.ts
+++ b/packages/app/src/api/types.ts
@@ -2,6 +2,7 @@ import { type PublicKey } from "@solana/web3.js";
 
 export interface MintResponse {
   timestamp: string;
+  sender?: string; // the wallet that pays for the mint (assume = the recipient if missing)
   recipient: string;
   amount: number;
 }
@@ -19,7 +20,8 @@ export interface MongoResponse<T> {
 
 export interface Mint {
   timestamp: Date;
-  recipient: PublicKey;
+  sender?: PublicKey; // the wallet that pays for the mint (assume = the recipient if missing)
+  recipient: PublicKey; // the wallet that receives the minted gSOL
   amount: number;
 }
 

--- a/packages/app/src/api/util.ts
+++ b/packages/app/src/api/util.ts
@@ -32,6 +32,27 @@ export const filterFirstTransfersForSenderAndRecipient = (
   return Object.values(firstTransfers);
 };
 
+const isMintTransfer = (mint: Mint): mint is Required<Mint> =>
+  mint.sender !== undefined && !mint.sender.equals(mint.recipient);
+
+/**
+ * Find all mints for which the recipient is not the sender and return them as transfers
+ * This ensures that transferred gSOL and gSOL that is minted directly into someone else's account
+ * are treated the same way
+ */
+export const mintsWithRecipientsAsTransfers = (mints: Mint[]): Transfer[] => {
+  return mints.filter(isMintTransfer).map((mint) => ({
+    amount: mint.amount,
+    sender: mint.sender,
+    recipient: mint.recipient,
+    timestamp: mint.timestamp,
+  }));
+};
+export const mintsToSelf = (mints: Mint[]): Mint[] =>
+  mints.filter(
+    (mint) => mint.sender === undefined || mint.sender.equals(mint.recipient)
+  );
+
 export const prune = (forest: Forest): Forest => {
   const seen: string[] = [];
   // if a tree node is in the seen array, it's a duplicate, remove it.

--- a/packages/app/src/common/components/modals/SendGSolModal.tsx
+++ b/packages/app/src/common/components/modals/SendGSolModal.tsx
@@ -203,7 +203,7 @@ const SendGSolModal: FC<ModalProps & SendGSolModalProps> = ({
           {currency === "SOL" ? (
             <div className="mt-2 mb-4 text-sm text-grey">
               <MdInfo className="inline stroke-grey" />
-              SOL gets staked and send as gSOL
+              SOL will be staked and sent as gSOL
             </div>
           ) : null}
           <div className="">

--- a/packages/app/src/tipjar/components/DonatableArtistNFT.tsx
+++ b/packages/app/src/tipjar/components/DonatableArtistNFT.tsx
@@ -71,8 +71,8 @@ export const DonatableArtistNFT: FC<Props> = ({ query, onDonate }) => {
             Recognition for those who deserve it.
           </h1>
           <p>
-            Received an Earth Day NFT? Drop some SOL in your artist&apos;s wallet.
-            DRiP is all about free art, so there&apos;s no obligation.
+            Received an Earth Day NFT? Drop some SOL in your artist&apos;s
+            wallet. DRiP is all about free art, so there&apos;s no obligation.
             Every lamport is appreciated!
           </p>
         </div>


### PR DESCRIPTION
When sending SOL in the grow page, the SOL is minted, which means these transfers show up as mints in the db. This ensures that mints where the sender and recipient are not the same, are represented as transfers on the forest.