### PR TITLE
Bug: Help icon/button becomes very tiny on smaller devices #236

### DIFF
--- a/packages/app/src/common/partials/Layout.tsx
+++ b/packages/app/src/common/partials/Layout.tsx
@@ -59,7 +59,7 @@ const Layout: FC<{ children: ReactNode }> = ({ children }) => {
         >
           <BsQuestionCircle
             size={40}
-            className="text-green-light w-4 md:w-12"
+            className="text-green-light w-12"
           />
         </button>
       </Transition>


### PR DESCRIPTION
if the size should stay the same change the md:w-12 ,w-4 tailwind classes and repalace it with w-12 class